### PR TITLE
Adds AuthnStatement claims for non-password authentication methods

### DIFF
--- a/source/WsFederationPlugin/ResponseHandling/SignInResponseGenerator.cs
+++ b/source/WsFederationPlugin/ResponseHandling/SignInResponseGenerator.cs
@@ -177,11 +177,19 @@ namespace IdentityServer3.WsFederation.ResponseHandling
                 }
             }
 
+            // The AuthnStatement statement generated from the following 2
+            // claims is manditory for some service providers (i.e. Shibboleth-Sp). 
+            // The value of the AuthenticationMethod claim must be one of the constants in
+            // System.IdentityModel.Tokens.AuthenticationMethods.
+            // Password is the only one that can be directly matched, everything
+            // else defaults to Unspecified.
             if (validationResult.Subject.GetAuthenticationMethod() == Constants.AuthenticationMethods.Password)
             {
                 mappedClaims.Add(new Claim(ClaimTypes.AuthenticationMethod, AuthenticationMethods.Password));
-                mappedClaims.Add(AuthenticationInstantClaim.Now);
+            } else {
+                mappedClaims.Add(new Claim(ClaimTypes.AuthenticationMethod, AuthenticationMethods.Unspecified));
             }
+            mappedClaims.Add(AuthenticationInstantClaim.Now);
             
             return new ClaimsIdentity(mappedClaims, "idsrv");
         }


### PR DESCRIPTION
The claims forming the AuthnStatement were only added when the authentication method is "password". An external authentication in IdentityServer3 sets the authentication method to "external", thus no AuthnStatement was generated and the service provider receiving the response could not create a session. This commit will cause the claims for AuthnStatement to be added always, if the authentication method differs from "password", the value for the AuthenticationMethod claim is AuthenticationMethods.Unspecified.
